### PR TITLE
Fixing AttributeError raising with old Django versions

### DIFF
--- a/windmill/authoring/djangotest.py
+++ b/windmill/authoring/djangotest.py
@@ -80,7 +80,7 @@ class TestServerThread(threading.Thread):
         # Must do database stuff in this new thread if database in memory.
         from django.conf import settings
         create_db = False
-        if settings.DATABASES:
+        if hasattr(settings, 'DATABASES') and settings.DATABASES:
             # Django > 1.2
             if settings.DATABASES['default']['ENGINE'] == 'django.db.backends.sqlite3' or \
                 settings.DATABASES['default']['TEST_NAME']:


### PR DESCRIPTION
I'm using windmill with django 1.0. DATABASES setting was introduced in django 1.2. So it is not present in settings module in earlier versions of the Django thus raising AttributeError when used without checking.
